### PR TITLE
update requirements to fix vulns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-beautifulsoup4==4.6.0
+beautifulsoup4==4.7.1
 bs4==0.0.1
-certifi==2017.11.5
+certifi==2018.11.29
 chardet==3.0.4
-idna==2.6
-pkg-resources==0.0.0
-requests==2.18.4
-urllib3==1.22
+idna==2.8
+requests==2.21.0
+soupsieve==1.7.3
+urllib3==1.24.1


### PR DESCRIPTION
This fixes security alerts for:
- `urllib3` - [CVE-2018-20060](https://nvd.nist.gov/vuln/detail/CVE-2018-20060)
- `requests` - [CVE-2018-18074](https://nvd.nist.gov/vuln/detail/CVE-2018-18074)